### PR TITLE
Fix native renderer rendering bug

### DIFF
--- a/engine/scene/graphics-render-handle.js
+++ b/engine/scene/graphics-render-handle.js
@@ -74,7 +74,7 @@ cc.js.mixin(renderer.GraphicsRenderHandle.prototype, {
         this.reserveMeshCount(index+1);
 
         this.vDatas[index] = vertices;
-        this.uintVDatas[index] = new Uint32Array(vertices.buffer);
+        this.uintVDatas[index] = new Uint32Array(vertices.buffer, 0, vertices.length);
         this.iDatas[index] = indices;
         this.meshCount = this.vDatas.length;
 

--- a/engine/scene/mask-render-handle.js
+++ b/engine/scene/mask-render-handle.js
@@ -23,12 +23,6 @@
 "use strict";
 
 cc.js.mixin(renderer.MaskRenderHandle.prototype, {
-    _ctor () {
-        this._comp = null;
-    },
-    destroy () {
-        this._comp = null;
-    },
     setNativeRenderHandle (handle) {
         if(handle) {
             this.setRenderSubHandle(handle);

--- a/engine/scene/node-proxy.js
+++ b/engine/scene/node-proxy.js
@@ -35,20 +35,20 @@ cc.js.mixin(renderer.NodeProxy.prototype, {
         {
             owner._proxy = this;
             this.updateZOrder();
-            this.updateGroupIndex();
+            this.updateCullingMask();
             this.updateJSTRS(owner._trs);
             if (owner._parent && owner._parent._proxy) {
                 this.updateParent(owner._parent._proxy);
             }
 
             owner.on(cc.Node.EventType.SIBLING_ORDER_CHANGED, this.updateZOrder, this);
-            owner.on(cc.Node.EventType.GROUP_CHANGED, this.updateGroupIndex, this);
+            owner.on(cc.Node.EventType.GROUP_CHANGED, this.updateCullingMask, this);
         }
     },
 
     unbind () {
         this._owner.off(cc.Node.EventType.SIBLING_ORDER_CHANGED, this.updateZOrder, this);
-        this._owner.off(cc.Node.EventType.GROUP_CHANGED, this.updateGroupIndex, this);
+        this._owner.off(cc.Node.EventType.GROUP_CHANGED, this.updateCullingMask, this);
         this._owner._proxy = null;
         this._owner = null;
         this.reset();
@@ -68,8 +68,8 @@ cc.js.mixin(renderer.NodeProxy.prototype, {
         this.setLocalZOrder(this._owner._localZOrder);
     },
 
-    updateGroupIndex () {
-        this.setGroupID(this._owner.groupIndex);
+    updateCullingMask () {
+        this.setCullingMask(this._owner._cullingMask);
     },
 
     updateOpacity () {

--- a/engine/scene/render-handle.js
+++ b/engine/scene/render-handle.js
@@ -66,7 +66,7 @@ cc.js.mixin(renderer.RenderHandle.prototype, {
         this.reserveMeshCount(index+1);
 
         this.vDatas[index] = vertices;
-        this.uintVDatas[index] = new Uint32Array(vertices.buffer);
+        this.uintVDatas[index] = new Uint32Array(vertices.buffer, 0, vertices.length);
         this.iDatas[index] = indices;
         this.meshCount = this.vDatas.length;
 


### PR DESCRIPTION
1 修复mask报错（覆盖了renderhandle的构造函数）
2 修复groupid为0时，没有使用父节点groupid的bug
3 修复bmfont updateColor时，渲染错误的bug